### PR TITLE
Add Next.js bilingual landing page, Tailwind setup and GitHub Pages deploy workflow

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,55 @@
+name: Deploy Next.js static site to GitHub Pages
+
+on:
+  push:
+    branches: ["main", "master"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build static site
+        run: npm run build
+        env:
+          GITHUB_ACTIONS: true
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./out
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Saíso Korean Food Market Landing Page
+
+Landing page premium, bilíngue (PT-BR/한국어), construída com Next.js + Tailwind CSS.
+
+## Publicação no GitHub Pages
+
+Este projeto já está configurado para deploy automático no **GitHub Pages**.
+
+### 1) Pré-requisitos
+- Repositório no GitHub com branch `main` (ou `master`).
+- GitHub Pages habilitado em **Settings → Pages → Source: GitHub Actions**.
+
+### 2) Como publicar
+1. Faça push deste código para `main` (ou `master`).
+2. O workflow `.github/workflows/deploy-pages.yml` será executado.
+3. A action gera o build estático (`out/`) e publica automaticamente no Pages.
+
+### 3) Observações técnicas
+- `next.config.mjs` usa `output: 'export'` para gerar site estático.
+- Em ambiente GitHub Actions, o `basePath` é ajustado automaticamente para repositórios do tipo `usuario/repositorio`.
+- Para repositórios `usuario.github.io`, o site é publicado na raiz.

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,30 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+}
+
+body {
+  @apply bg-white text-saisoDark antialiased;
+}
+
+.section-wrap {
+  @apply mx-auto max-w-6xl px-4 sm:px-6 lg:px-8;
+}
+
+.fade-in-up {
+  animation: fadeInUp 0.6s ease both;
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(14px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from 'next';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'Saíso Korean Food Market',
+  description:
+    'Saíso Korean Food Market - Restaurante e Mercearia Coreana com foco em experiência, cultura e bons momentos.'
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="pt-BR">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,5 @@
+import LandingPage from '@/components/landing-page';
+
+export default function Home() {
+  return <LandingPage />;
+}

--- a/components/landing-page.tsx
+++ b/components/landing-page.tsx
@@ -1,0 +1,297 @@
+'use client';
+
+import Image from 'next/image';
+import { useMemo, useState } from 'react';
+import {
+  CalendarDays,
+  Camera,
+  ExternalLink,
+  Heart,
+  MapPin,
+  MessageCircleHeart,
+  Music2,
+  ShoppingBag,
+  Sparkles,
+  Star,
+  Store,
+  UtensilsCrossed
+} from 'lucide-react';
+
+type Locale = 'pt' | 'ko';
+
+const translations = {
+  pt: {
+    subname: 'Restaurante e Mercearia Coreana',
+    headline: 'Sabores da Coreia, uma experiência para viver',
+    institutional:
+      'No Saíso, você encontra mais do que comida coreana. Aqui, cada detalhe foi pensado para criar uma experiência que conecta sabores, cultura e bons momentos em um só lugar.',
+    kculture:
+      'Um espaço para quem ama cultura coreana, encontros especiais e ambientes cheios de personalidade.',
+    market:
+      'Além da experiência no restaurante, você também encontra itens selecionados da mercearia coreana para levar um pedacinho da Coreia com você.',
+    ctaReserve: 'Reservar',
+    ctaAddress: 'Ver endereço',
+    ctaIfood: 'Pedir no iFood',
+    nav: ['Experiência', 'Eventos', 'Galeria', 'Avaliações', 'Links rápidos'],
+    welcome: '어서 오세요 · Seja bem-vindo',
+    moreThanFood: 'Mais que comida',
+    moreCards: ['Restaurante Coreano', 'Mercearia Especial', 'Ambiente Instagramável', 'Experiência Cultural'],
+    kTitle: 'K-Culture Experience',
+    kTagline: 'Seu novo lugar favorito para viver a vibe coreana.',
+    eventsTitle: 'Acontece no Saíso',
+    galleryTitle: 'Galeria instagramável',
+    galleryTagline: 'Seu próximo story favorito começa aqui.',
+    marketTitle: 'Mercado Coreano',
+    testimonialsTitle: 'Avaliações e prova social',
+    quickLinksTitle: 'Acesse em um clique',
+    googleCta: 'Nos avalie no Google',
+    footerText: 'Saíso é encontro, cultura e sabor em uma experiência coreana contemporânea.'
+  },
+  ko: {
+    subname: '한식 레스토랑 & 마켓',
+    headline: '한국의 맛, 특별한 경험',
+    institutional:
+      '사이소는 단순한 한식당이 아닙니다. 음식, 문화, 분위기가 어우러진 특별한 공간을 제공합니다.',
+    kculture: '한국 문화를 사랑하는 사람들을 위한 감각적인 공간.',
+    market: '레스토랑 경험뿐 아니라 다양한 한국 마켓 상품도 함께 만나보세요.',
+    ctaReserve: '예약하기',
+    ctaAddress: '주소 보기',
+    ctaIfood: 'iFood 주문하기',
+    nav: ['경험', '이벤트', '갤러리', '리뷰', '빠른 링크'],
+    welcome: '어서 오세요 · 환영합니다',
+    moreThanFood: '음식 그 이상',
+    moreCards: ['한식 레스토랑', '프리미엄 마켓', '인스타그래머블 공간', '문화 체험'],
+    kTitle: 'K-Culture Experience',
+    kTagline: '한국 감성을 즐기는 당신을 위한 새로운 아지트.',
+    eventsTitle: '사이소 이벤트',
+    galleryTitle: '인스타그래머블 갤러리',
+    galleryTagline: '당신의 다음 스토리는 여기에서 시작됩니다.',
+    marketTitle: '코리안 마켓',
+    testimonialsTitle: '리뷰 & 소셜 프루프',
+    quickLinksTitle: '바로가기',
+    googleCta: 'Google 리뷰 남기기',
+    footerText: '사이소는 맛과 문화, 그리고 특별한 순간이 만나는 공간입니다.'
+  }
+} as const;
+
+const quickLinks = [
+  { href: '#cardapio', labelPt: 'Cardápio', labelKo: '메뉴', subtitlePt: 'Acesse o sistema externo', subtitleKo: '외부 메뉴 보기' },
+  { href: '#reserva', labelPt: 'Faça sua reserva', labelKo: '예약하기', subtitlePt: 'Garanta seu lugar', subtitleKo: '자리 예약하기' },
+  { href: '#ifood', labelPt: 'Peça no iFood', labelKo: 'iFood 주문', subtitlePt: 'Peça com praticidade', subtitleKo: '편하게 주문하기' },
+  { href: '#instagram', labelPt: 'Instagram', labelKo: '인스타그램', subtitlePt: 'Veja novidades diárias', subtitleKo: '매일 업데이트' },
+  { href: '#google', labelPt: 'Nos avalie no Google', labelKo: 'Google 리뷰', subtitlePt: 'Compartilhe sua experiência', subtitleKo: '경험을 공유해 주세요' },
+  { href: '#endereco', labelPt: 'Endereço', labelKo: '주소', subtitlePt: 'Como chegar ao Saíso', subtitleKo: '사이소 오시는 길' }
+];
+
+const events = [
+  { badge: 'Em breve', titlePt: 'Noite temática K-Vibe', titleKo: 'K-Vibe 테마 나이트', date: '26/04', descPt: 'Playlist especial, clima vibrante e experiências para compartilhar.', descKo: '특별한 플레이리스트와 감각적인 분위기.' },
+  { badge: 'Em breve', titlePt: 'Encontro de fãs', titleKo: '팬 모임', date: '03/05', descPt: 'Um espaço para conexões e bons momentos entre apaixonados por cultura coreana.', descKo: '한국 문화를 사랑하는 사람들의 특별한 만남.' },
+  { badge: 'Em breve', titlePt: 'Experiência sazonal', titleKo: '시즌 스페셜', date: '17/05', descPt: 'Ações especiais no salão e no mercado para viver novas descobertas.', descKo: '레스토랑과 마켓에서 즐기는 시즌 한정 경험.' }
+];
+
+const testimonials = [
+  { name: 'Marina L.', textPt: 'Ambiente lindo, atendimento incrível e uma experiência que dá vontade de voltar toda semana.', textKo: '분위기도 좋고 서비스도 훌륭해서 자주 오고 싶어요.' },
+  { name: 'Rafael K.', textPt: 'O Saíso virou nosso ponto de encontro. Perfeito para fotos e para curtir com amigos.', textKo: '사진도 예쁘게 나오고 친구들과 즐기기 좋은 공간이에요.' },
+  { name: 'Jisoo P.', textPt: 'A combinação de restaurante e mercearia é maravilhosa. Tudo com identidade e cuidado.', textKo: '레스토랑과 마켓을 함께 즐길 수 있어 정말 만족스러워요.' }
+];
+
+export default function LandingPage() {
+  const [locale, setLocale] = useState<Locale>('pt');
+  const t = translations[locale];
+
+  const kBlocks = useMemo(
+    () => [
+      { icon: Camera, pt: 'Espaços para fotos', ko: '포토 스팟' },
+      { icon: Music2, pt: 'Atmosfera pop coreana', ko: 'K-POP 감성' },
+      { icon: Heart, pt: 'Encontros memoráveis', ko: '특별한 만남' },
+      { icon: Sparkles, pt: 'Design urbano premium', ko: '프리미엄 무드' }
+    ],
+    []
+  );
+
+  return (
+    <div className="bg-white">
+      <header className="sticky top-0 z-50 border-b border-slate-200/80 bg-white/90 backdrop-blur">
+        <div className="section-wrap flex items-center justify-between py-4">
+          <div>
+            <p className="text-lg font-bold text-saisoDark">Saíso Korean Food Market</p>
+            <p className="text-xs text-slate-500">{t.subname}</p>
+          </div>
+          <nav className="hidden gap-6 text-sm text-slate-700 lg:flex">
+            {t.nav.map((item) => (
+              <a className="transition hover:text-saisoBlue" href="#" key={item}>
+                {item}
+              </a>
+            ))}
+          </nav>
+          <div className="flex items-center gap-2">
+            <button
+              className={`rounded-full px-3 py-1 text-xs font-semibold transition ${locale === 'pt' ? 'bg-saisoBlue text-white' : 'bg-slate-100 text-slate-700'}`}
+              onClick={() => setLocale('pt')}
+              type="button"
+            >
+              PT-BR
+            </button>
+            <button
+              className={`rounded-full px-3 py-1 text-xs font-semibold transition ${locale === 'ko' ? 'bg-saisoRed text-white' : 'bg-slate-100 text-slate-700'}`}
+              onClick={() => setLocale('ko')}
+              type="button"
+            >
+              한국어
+            </button>
+            <a className="hidden rounded-full bg-saisoBlue px-4 py-2 text-sm font-semibold text-white shadow-soft transition hover:-translate-y-0.5 hover:bg-blue-600 sm:inline-flex" href="#reserva">
+              {t.ctaReserve}
+            </a>
+          </div>
+        </div>
+      </header>
+
+      <main>
+        <section className="section-wrap grid gap-8 py-12 md:grid-cols-2 md:py-20" id="reserva">
+          <div className="fade-in-up space-y-6">
+            <span className="inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600">{t.welcome}</span>
+            <h1 className="text-4xl font-bold leading-tight text-saisoDark md:text-5xl">{t.headline}</h1>
+            <p className="text-base text-slate-600 md:text-lg">{t.institutional}</p>
+            <div className="flex flex-wrap gap-3">
+              <a className="rounded-full bg-saisoBlue px-5 py-3 text-sm font-semibold text-white transition hover:-translate-y-0.5 hover:bg-blue-600" href="#reserva">{t.ctaReserve}</a>
+              <a className="rounded-full border border-slate-300 px-5 py-3 text-sm font-semibold text-slate-700 transition hover:border-saisoBlue hover:text-saisoBlue" href="#endereco">{t.ctaAddress}</a>
+              <a className="rounded-full bg-saisoRed px-5 py-3 text-sm font-semibold text-white transition hover:-translate-y-0.5 hover:bg-red-500" href="#ifood">{t.ctaIfood}</a>
+            </div>
+          </div>
+          <div className="relative overflow-hidden rounded-3xl border border-slate-200 shadow-soft">
+            <Image alt="Ambiente premium coreano" className="h-full w-full object-cover" height={900} src="https://images.unsplash.com/photo-1559339352-11d035aa65de?auto=format&fit=crop&w=1400&q=80" width={1200} />
+            <div className="absolute inset-0 bg-gradient-to-t from-black/40 to-transparent" />
+            <p className="absolute bottom-4 left-4 rounded-full bg-white/90 px-3 py-1 text-xs font-semibold text-slate-700">예약 · Reserva | 주소 · Endereço</p>
+          </div>
+        </section>
+
+        <section className="section-wrap py-12" id="experiencia">
+          <h2 className="text-3xl font-bold">{t.moreThanFood}</h2>
+          <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            {[UtensilsCrossed, ShoppingBag, Camera, Sparkles].map((Icon, idx) => (
+              <article className="rounded-2xl border border-slate-200 p-5 shadow-soft transition hover:-translate-y-1" key={t.moreCards[idx]}>
+                <Icon className="mb-4 h-5 w-5 text-saisoBlue" />
+                <h3 className="font-semibold">{t.moreCards[idx]}</h3>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="bg-slate-50 py-14">
+          <div className="section-wrap">
+            <h2 className="text-3xl font-bold">{t.kTitle}</h2>
+            <p className="mt-3 max-w-3xl text-slate-600">{t.kculture} {t.kTagline}</p>
+            <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+              {kBlocks.map(({ icon: Icon, pt, ko }) => (
+                <div className="rounded-2xl bg-white p-5 shadow-soft" key={pt}>
+                  <Icon className="h-5 w-5 text-saisoRed" />
+                  <p className="mt-3 font-semibold">{locale === 'pt' ? pt : ko}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="section-wrap py-14" id="eventos">
+          <h2 className="text-3xl font-bold">{t.eventsTitle}</h2>
+          <div className="mt-8 grid gap-4 md:grid-cols-3">
+            {events.map((event) => (
+              <article className="rounded-2xl border border-slate-200 p-5 shadow-soft" key={event.titlePt}>
+                <span className="rounded-full bg-saisoBlue/10 px-3 py-1 text-xs font-semibold text-saisoBlue">{event.badge}</span>
+                <h3 className="mt-4 font-semibold">{locale === 'pt' ? event.titlePt : event.titleKo}</h3>
+                <p className="mt-2 text-sm text-slate-500">{event.date}</p>
+                <p className="mt-3 text-sm text-slate-600">{locale === 'pt' ? event.descPt : event.descKo}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="bg-slate-50 py-14" id="galeria">
+          <div className="section-wrap">
+            <h2 className="text-3xl font-bold">{t.galleryTitle}</h2>
+            <p className="mt-3 text-slate-600">{t.galleryTagline}</p>
+            <div className="mt-8 grid grid-cols-2 gap-3 md:grid-cols-4">
+              {[
+                'photo-1473091534298-04dcbce3278c',
+                'photo-1517248135467-4c7edcad34c4',
+                'photo-1498654896293-37aacf113fd9',
+                'photo-1552566626-52f8b828add9',
+                'photo-1528605248644-14dd04022da1',
+                'photo-1466978913421-dad2ebd01d17',
+                'photo-1504674900247-0877df9cc836',
+                'photo-1555396273-367ea4eb4db5'
+              ].map((id) => (
+                <div className="relative h-40 overflow-hidden rounded-2xl" key={id}>
+                  <Image alt="Saíso experience" className="h-full w-full object-cover transition duration-300 hover:scale-105" fill sizes="(max-width:768px) 50vw, 25vw" src={`https://images.unsplash.com/${id}?auto=format&fit=crop&w=900&q=80`} />
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="section-wrap py-14" id="endereco">
+          <div className="rounded-3xl border border-slate-200 bg-white p-8 shadow-soft">
+            <h2 className="text-3xl font-bold">{t.marketTitle}</h2>
+            <p className="mt-4 max-w-3xl text-slate-600">{t.market}</p>
+            <p className="mt-4 text-sm text-slate-500">Snack · Drinks · Ramen · Sweets · Special Finds</p>
+            <a className="mt-6 inline-flex rounded-full bg-saisoBlue px-5 py-3 text-sm font-semibold text-white transition hover:bg-blue-600" href="#endereco">{locale === 'pt' ? 'Visitar o espaço' : '매장 방문하기'}</a>
+          </div>
+        </section>
+
+        <section className="bg-slate-50 py-14" id="reviews">
+          <div className="section-wrap">
+            <h2 className="text-3xl font-bold">{t.testimonialsTitle}</h2>
+            <div className="mt-7 grid gap-4 md:grid-cols-3">
+              {testimonials.map((item) => (
+                <article className="rounded-2xl bg-white p-5 shadow-soft" key={item.name}>
+                  <Star className="h-5 w-5 text-saisoRed" />
+                  <p className="mt-4 text-slate-600">“{locale === 'pt' ? item.textPt : item.textKo}”</p>
+                  <p className="mt-4 text-sm font-semibold">{item.name}</p>
+                </article>
+              ))}
+            </div>
+            <a className="mt-6 inline-flex rounded-full border border-slate-300 px-5 py-3 text-sm font-semibold text-slate-700 transition hover:border-saisoRed hover:text-saisoRed" href="#google">{t.googleCta}</a>
+          </div>
+        </section>
+
+        <section className="section-wrap py-14" id="links">
+          <h2 className="text-3xl font-bold">{t.quickLinksTitle}</h2>
+          <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {quickLinks.map((link) => (
+              <a className="group rounded-2xl border border-slate-200 p-5 shadow-soft transition hover:-translate-y-1 hover:border-saisoBlue" href={link.href} key={link.href}>
+                <ExternalLink className="h-5 w-5 text-saisoBlue" />
+                <p className="mt-4 font-semibold">{locale === 'pt' ? link.labelPt : link.labelKo}</p>
+                <p className="text-sm text-slate-500">{locale === 'pt' ? link.subtitlePt : link.subtitleKo}</p>
+                <span className="mt-3 inline-flex text-xs font-semibold text-saisoBlue group-hover:underline">{locale === 'pt' ? 'Abrir link' : '링크 열기'}</span>
+              </a>
+            ))}
+          </div>
+        </section>
+      </main>
+
+      <footer className="border-t border-slate-200 py-10" id="ifood">
+        <div className="section-wrap grid gap-8 md:grid-cols-3">
+          <div>
+            <p className="text-lg font-bold">Saíso Korean Food Market</p>
+            <p className="text-sm text-slate-500">{t.subname}</p>
+            <p className="mt-3 text-sm text-slate-600">{t.footerText}</p>
+          </div>
+          <div>
+            <p className="font-semibold">Contato</p>
+            <ul className="mt-3 space-y-2 text-sm text-slate-600">
+              <li className="flex items-center gap-2"><MessageCircleHeart className="h-4 w-4" /> +55 (11) 99999-0000</li>
+              <li className="flex items-center gap-2"><MapPin className="h-4 w-4" /> Rua Exemplo, 123 - São Paulo</li>
+              <li className="flex items-center gap-2"><CalendarDays className="h-4 w-4" /> Terça a Domingo</li>
+            </ul>
+          </div>
+          <div className="space-y-2 text-sm">
+            <a className="flex items-center gap-2 text-slate-700 hover:text-saisoBlue" href="#reserva"><Store className="h-4 w-4" /> {t.ctaReserve}</a>
+            <a className="flex items-center gap-2 text-slate-700 hover:text-saisoBlue" href="#ifood"><ShoppingBag className="h-4 w-4" /> iFood</a>
+            <a className="flex items-center gap-2 text-slate-700 hover:text-saisoBlue" href="#instagram"><Camera className="h-4 w-4" /> Instagram</a>
+          </div>
+        </div>
+        <p className="mt-8 text-center text-xs text-slate-500">© {new Date().getFullYear()} Saíso Korean Food Market. All rights reserved.</p>
+      </footer>
+    </div>
+  );
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,23 @@
+const isGithubActions = process.env.GITHUB_ACTIONS === 'true';
+const repository = process.env.GITHUB_REPOSITORY?.replace(/.*\//, '') ?? '';
+const isUserOrOrgSite = repository.endsWith('.github.io');
+const basePath = isGithubActions && !isUserOrOrgSite ? `/${repository}` : '';
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'export',
+  trailingSlash: true,
+  basePath,
+  assetPrefix: basePath,
+  images: {
+    unoptimized: true,
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'images.unsplash.com'
+      }
+    ]
+  }
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "saiso-landing",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "lucide-react": "^0.511.0",
+    "next": "14.2.5",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.10",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "autoprefixer": "^10.4.19",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "14.2.5",
+    "postcss": "^8.4.39",
+    "tailwindcss": "^3.4.4",
+    "typescript": "^5.5.3"
+  }
+}

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,23 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: [
+    './app/**/*.{js,ts,jsx,tsx,mdx}',
+    './components/**/*.{js,ts,jsx,tsx,mdx}'
+  ],
+  theme: {
+    extend: {
+      colors: {
+        saisoBlue: '#2B6CFF',
+        saisoRed: '#E73B3B',
+        saisoDark: '#121826'
+      },
+      boxShadow: {
+        soft: '0 10px 30px rgba(16, 24, 40, 0.08)'
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
### Motivation
- Provide a starting Next.js app for a bilingual (PT-BR / Korean) landing page with a static export target for GitHub Pages.
- Standardize styling with Tailwind CSS and project TypeScript configuration to enable fast iteration and consistent design tokens.
- Ensure automated deployment by adding a GitHub Actions workflow to build and publish the static `out/` site.

### Description
- Added the Next.js app structure and UI: `app/layout.tsx`, `app/page.tsx`, `app/globals.css`, and a full `components/landing-page.tsx` implementing bilingual content and UI blocks.
- Added project configuration and toolchain files: `package.json`, `tsconfig.json`, `next-env.d.ts`, `next.config.mjs`, `tailwind.config.ts`, `postcss.config.mjs`, and `.eslintrc.json` with `output: 'export'`, image remote patterns, Tailwind tokens, and linting config.
- Added CI/CD workflow ` .github/workflows/deploy-pages.yml` that installs dependencies, runs `npm run build`, uploads `./out`, and deploys to GitHub Pages.
- Included a `README.md` documenting deployment steps and notes about `next.config.mjs` basePath behavior for GitHub Pages.

### Testing
- No automated tests were included or executed as part of this PR.
- The added GitHub Actions workflow is configured to run `npm install` and `npm run build` on push to `main`/`master`, then upload `./out` and deploy to Pages when triggered.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2d7c23248832ea2b88bbdebea29c9)